### PR TITLE
AESinkAudioTrack: Fix Print for TimeStampDelay

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -152,6 +152,13 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
     status.delay += static_cast<double>(m_bufferedSamples) *
                     m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
+  if (!m_pcmOutput && m_sinkNeedIecPack &&
+      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
+  {
+    // take into account MAT packer latency
+    status.delay += 12.0 * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+  }
+
   for (auto &str : m_streamStats)
   {
     if (str.m_streamId == stream->m_id)
@@ -177,6 +184,13 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
         static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
+
+  if (!m_pcmOutput && m_sinkNeedIecPack &&
+      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
+  {
+    // take into account MAT packer latency
+    status.delay += 12.0 * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+  }
 
   for (auto &str : m_streamStats)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -77,7 +77,7 @@ void CEngineStats::GetDelay(AEDelayStatus& status)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
     status.delay += static_cast<double>(m_bufferedSamples) *
-                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
+                    m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 }
 
 void CEngineStats::AddStream(unsigned int streamid)
@@ -131,7 +131,7 @@ void CEngineStats::UpdateStream(CActiveAEStream *stream)
           delay += (float)(*itBuf)->pkt->nb_samples / (*itBuf)->pkt->config.sample_rate;
         else
           delay +=
-              static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000.0);
+              static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration() / 1000.0);
       }
       str.m_bufferedTime = static_cast<double>(delay);
       stream->m_bufferedTime = 0;
@@ -150,7 +150,7 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
     status.delay += static_cast<double>(m_bufferedSamples) *
-                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
+                    m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   for (auto &str : m_streamStats)
   {
@@ -173,8 +173,8 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += static_cast<double>(m_bufferedSamples) *
-                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
+    status.delay +=
+        static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
 
@@ -233,9 +233,8 @@ float CEngineStats::GetWaterLevel()
   }
   else
   {
-    float wl = static_cast<float>(m_bufferedSamples *
-                                  m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack)) /
-               1000;
+    float wl =
+        static_cast<float>(m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration()) / 1000;
 
     if (wl >= MAX_WATER_LEVEL)
       wl = MAX_WATER_LEVEL - 0.00001f;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -727,7 +727,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
                 1000.0 * (m_duration_written - playtime), delta / 1000000.0, playtime * 1000,
                 m_duration_written * 1000);
       CLog::Log(LOGINFO, "Head-Position {} Timestamp Position {} Delay-Offset: {} ms", m_headPos,
-                m_timestampPos, 1000.0 * (m_headPos - m_timestampPos) / m_sink_sampleRate);
+                m_timestampPos, 1000.0 * (static_cast<int64_t>(m_headPos - m_timestampPos)) / m_sink_sampleRate);
     }
     double hw_delay = m_duration_written - playtime;
     // correct by subtracting above measured delay, if lower delay gets automatically reduced

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -61,7 +61,7 @@ CAEStreamParser::CAEStreamParser() :
   av_crc_init(m_crcTrueHD, 0, 16, 0x2D, sizeof(m_crcTrueHD));
 }
 
-double CAEStreamInfo::GetDuration(bool TrueHDHalfDuration /*= false*/) const
+double CAEStreamInfo::GetDuration() const
 {
   double duration = 0;
   switch (m_type)
@@ -81,8 +81,6 @@ double CAEStreamInfo::GetDuration(bool TrueHDHalfDuration /*= false*/) const
       else
         rate = 176400;
       duration = 3840.0 / rate;
-      if (TrueHDHalfDuration)
-        duration /= 2;
       break;
     case STREAM_TYPE_DTS_512:
     case STREAM_TYPE_DTSHD_CORE:

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -22,7 +22,7 @@ extern "C" {
 class CAEStreamInfo
 {
 public:
-  double GetDuration(bool TrueHDHalfDuration = false) const;
+  double GetDuration() const;
   bool operator==(const CAEStreamInfo& info) const;
 
   enum DataType

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -224,7 +224,7 @@ void CDVDAudioCodecPassthrough::GetData(DVDAudioFrame &frame)
   frame.format = m_format;
   frame.planes = 1;
   frame.bits_per_sample = 8;
-  frame.duration = DVD_MSEC_TO_TIME(frame.format.m_streamInfo.GetDuration(!m_deviceIsRAW));
+  frame.duration = DVD_MSEC_TO_TIME(frame.format.m_streamInfo.GetDuration());
   frame.pts = m_currentPts;
   m_currentPts = DVD_NOPTS_VALUE;
 }

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -858,9 +858,8 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
       {
-        const bool isIEC = !m_processInfo->WantsRawPassthrough();
-        free_space = (double)si->m_stream->GetSpace() *
-                     si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000;
+        free_space = static_cast<double>(si->m_stream->GetSpace()) *
+                     si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
       }
 
       freeBufferTime = std::max(freeBufferTime , free_space);
@@ -909,8 +908,7 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      const bool isIEC = !m_processInfo->WantsRawPassthrough();
-      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000 *
+      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
                           si->m_audioFormat.m_streamInfo.m_sampleRate;
     }
   }


### PR DESCRIPTION
When the original HeadPosition did not yet move the TimeStamp which is interpolated will already have moved. The print worked on unsigned and did not take this case into account. Fix it by a cast.